### PR TITLE
Link directly to E6 posts rather than a search for its MD5

### DIFF
--- a/app/views/links/_details.html.erb
+++ b/app/views/links/_details.html.erb
@@ -1,5 +1,5 @@
 <% target = "link_details_#{link.id}" %>
-<% e621_url = "https://e621.net/posts?tags=#{ CGI.escape("md5:#{ link.post_url[/\w*(?=\.(png|jpg|bmp|webm|gif)$)/] }") }" if link.post_url %>
+<% e621_url = "https://e621.net/posts?md5=#{ CGI.escape(link.post_url[/\w*(?=\.(png|jpg|bmp|webm|gif)$)/]) }" if link.post_url %>
 <% client = link_agent_to_icon link.last_ping_user_agent %>
 <% devices = {
   desktop: :desktop,


### PR DESCRIPTION
I think I removed a bit of superfluous string interpolation but there's no syntax highlighting so I'm only mostly sure this is valid syntax :")