### PR TITLE
New multiplier-based browse page algorithm

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -36,7 +36,7 @@ class LinksController < ApplicationController
           .joins(:past_links)
           .where('past_links.created_at = (SELECT MAX(created_at) FROM past_links WHERE past_links.link_id = links.id)')
           .order(Arel.sql(%q{
-                    past_links.created_at - make_interval(secs := users.set_count * 6) ASC
+                    EXTRACT (EPOCH FROM AGE(NOW(), past_links.created_at)) * (1 + (users.set_count / 3000.0)) DESC
                  }))
           .limit(18)
           .pluck(:id)


### PR DESCRIPTION
The current browse page algorithm shows the 18 "oldest" links, but considers each user's links to be 6 seconds "older" for each wallpaper they've set for others. In practice, this bonus doesn't really do much for people outside of Anonymous23, since that guy's just built different.

The goal here is to replace the system with a multiplier-based algorithm, where the relative age of a link is multiplied by some factor of how many wallpapers that user has set for others. This should help push active users to the forefront of the browse page without completely burying the less active users.