### PR TITLE
remove false browse page info in the orgasm text

### DIFF
--- a/nuttracker/app/views/nuttracker/orgasms/_form.html.erb
+++ b/nuttracker/app/views/nuttracker/orgasms/_form.html.erb
@@ -11,7 +11,7 @@
       </h2>
 
       <p>
-        A logged orgasm is recorded on your public profile, and will benefit your ranking on the browse page! It's also just fun.
+        An orgasm will be recorded on your public profile for everyone to see! It's fun!
       </p>
 
       <div class="flashes">


### PR DESCRIPTION
The current browse page rankings don't use the orgasm log at all, so let's remove that text.