### PR TITLE
Change "no links" text to nudge new users towards the link wizard

### DIFF
--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -28,8 +28,8 @@
   <% if @links.count == 0 %>
     <h4>No links?</h4>
     <p>
-      You'll need to click <span class="mock-button">New link</span> in the toolbar to set up a link that others can use
-      to push wallpapers to your device.
+      You'll need to create a link that others can use to push wallpapers to your device. Try the 
+      <span class="mock-link"><ion-icon role="presentation" name="color-wand"></ion-icon> Link Wizard</span>for a guided tutorial!
     </p>
   <% end %>
 </div>


### PR DESCRIPTION
Currently, the text instructs new users to hit the "new link" button, but for a new user it's probably best if we nudge them towards the wizard for their first time.