### PR TITLE
drastically improve firefox scroll performance, minor chrome improvement

### DIFF
--- a/public/link.css
+++ b/public/link.css
@@ -91,6 +91,11 @@ strong.search-heading {
                          'terms        blacklist'
                          'friends-only friends-only';
     overflow: hidden;
+    /* Extreme improvement to scrolling performance in firefox, minor improvement in chrome,
+    caused by excessive, expensive re-rendering of filtered images combined with blending modes. 
+    this style forces them into their own GPU surfaces, preventing the re-rendering at the cost of 
+    blending accuracy */
+    will-change: transform;
 }
 
 .text-light {
@@ -245,6 +250,7 @@ a:hover > .link {
     z-index: -1;
     mix-blend-mode: color-dodge;
     opacity: 0.3;
+    filter: contrast(150%) saturate(200%);
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
this is a short 3-line CSS change

it turns out that browsers are really inefficient at repainting filtered images that are rendered transparently. Firefox is the worst about this, going from ~70-80% usage of my intel igpu to ~20-30% after the change when fervently scrolling. Chrome also has a bump, although it doesn't barf nearly as hard to begin with: ~25-30% to ~20-25%. This has more significant implications on mobile devices.

using `will-change: transform` to force them into a GPU surface fixes this performance, but with one caveat: the transparent link number text/emoji slightly changes colors, as the color dodge filter now no longer factors in the page's background. I added some contrast and saturation to try and keep the emojis from looking too washed out, but the colors still don't match exactly.