### PR TITLE
Walltaker engine does not work on Windows 11 24H2.

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -126,7 +126,7 @@
   <tr>
     <td><a href="https://github.com/dogkisser/walltaker-engine/releases" target="_blank">Chewtoy's Walltaker Engine</a>
     </td>
-    <td>Windows</td>
+    <td>Windows 10/11 (21H2-23H2)</td>
   </tr>
   <tr>
     <td><a href="https://github.com/gios2/Walltaker-Changer/releases/latest" target="_blank">Gios' Client</a></td>


### PR DESCRIPTION
Mentioned that Walltaker client currently only works on Windows 10 through Windows 11 23H2 (Build 22621/31)