### PR TITLE
Fix Dockerfile ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.0
+FROM ruby:3.3.4
 
 # Prepare working directory.
 WORKDIR /ror


### PR DESCRIPTION
Dockerfile references an outdated version of ruby, update to 3.3.4 to match the gemfile.

there are still other things that you have to do for cold-start development that aren't addressed in this pr since they have some level of actual thinking i'd have to do:  
- changing the Dockerfile rails env to development
- Dockerfile fixes for WSL (must use named volumes)
- docker-compose: must set postgres credentials or trust mode