### PR TITLE
Fix port forwarding in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./:/ror
     ports:
-      - "3000:3100"
+      - "3100:3000"
     depends_on:
       - database
     environment:


### PR DESCRIPTION
Ports were backwards, needs to be fixed before local docker instances work

Docker ports are HOST:CONTAINER. docker-compose docs annoyingly glaze over that, assuming you'll just figure out that it's the same as the CLI syntax