### PR TITLE
Add ability to expand/contract image preview on link page

### DIFF
--- a/app/javascript/controllers/embiggen_toggle_controller.js
+++ b/app/javascript/controllers/embiggen_toggle_controller.js
@@ -1,0 +1,25 @@
+import {Controller} from "@hotwired/stimulus"
+
+export default class EmbiggenToggleController extends Controller {
+    connect()  {
+        this.tick();
+    }
+    toggle () {
+        if (window.sessionStorage.getItem("embiggen-link-image") === "false") {
+            window.sessionStorage.setItem("embiggen-link-image", "true")
+        }
+        else {
+            window.sessionStorage.setItem("embiggen-link-image", "false")
+        }
+        this.tick()
+    }
+
+    tick () {
+        if (window.sessionStorage.getItem("embiggen-link-image") === "false") {
+            this.element.classList.remove("embiggened")
+        }
+        else {
+            this.element.classList.add("embiggened");
+        }
+    }
+}

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -1,6 +1,7 @@
 <% mascot = current_user&.mascot || 'ki' %>
+<% pervert = current_user&.pervert || false %>
 <!DOCTYPE html>
-<html class="<%= current_user ? "force-#{current_user.colour_preference}" : "" %>">
+<html class="<%= current_user ? "force-#{current_user.colour_preference}" : ""%> <%= "current-mascot-"+mascot %> <%=pervert ? "currently-perverted" : ""%> ">
 <head>
   <title><%= content_for?(:html_title) ? yield(:html_title) : "Walltaker" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1">

--- a/app/views/links/_details.html.erb
+++ b/app/views/links/_details.html.erb
@@ -46,22 +46,40 @@
   </h2>
 
   <% if link.post_thumbnail_url && link.post_url %>
-    <figure>
+    <figure data-controller="embiggen-toggle">
       <a href="<%= link.post_url %>" target="_blank" class="background-sample">
         <% case device %>
         <% when :desktop %>
-          <ion-icon role="presentation" name="laptop-outline" class="background-sample__icon--desktop"></ion-icon>
+          <ion-icon role="presentation" name="laptop-outline" class="background-sample__icon--desktop hide-when-embiggened"></ion-icon>
         <% when :mobile %>
-          <ion-icon role="presentation" name="phone-portrait-outline" class="background-sample__icon--mobile"></ion-icon>
+          <ion-icon role="presentation" name="phone-portrait-outline" class="background-sample__icon--mobile hide-when-embiggened"></ion-icon>
         <% end %>
 
-        <img src="<%= link.post_thumbnail_url %>" class="background-sample__image--<%= device %>"/>
+        <img src="<%= link.post_thumbnail_url %>" class="embiggen-me-daddy background-sample__image--<%= device %>"/>
       </a>
       <figcaption class="link--description">
+      <div class="embiggen-button-container"> 
+        <button type="button" data-action="click->embiggen-toggle#toggle">
+          <ion-icon name="expand" class="text-embiggen"></ion-icon>
+          <ion-icon name="contract" class="text-ensmallen"></ion-icon>
+          <span class="show-for-warren show-for-perverts text-embiggen">MAKE IT HUGE!</span>
+          <span class="show-for-warren show-for-nonperverts text-embiggen">Bigger</span>
+          <span class="show-for-warren show-for-perverts text-ensmallen">MAKE IT TINY!</span>
+          <span class="show-for-warren show-for-nonperverts text-ensmallen">Smaller</span>
+          <span class="show-for-taylor show-for-perverts text-embiggen">Show it all~!</span>
+          <span class="show-for-taylor show-for-nonperverts text-embiggen">Show more</span>
+          <span class="show-for-taylor show-for-perverts text-ensmallen">Cover up a little~</span>
+          <span class="show-for-taylor show-for-nonperverts text-ensmallen">Show less</span>
+          <span class="show-for-ki show-for-perverts text-embiggen">Let's get up close~</span>
+          <span class="show-for-ki show-for-nonperverts text-embiggen">Expand</span>
+          <span class="show-for-ki show-for-perverts text-ensmallen">That's plenty~</span>
+          <span class="show-for-ki show-for-nonperverts text-ensmallen">Collapse</span>
+        </button>
         <%= link_to e621_url, class: 'small' do %>
           Show on E621
           <ion-icon role="presentation" name="arrow-forward"></ion-icon>
         <% end %>
+      </div>
         <%= simple_format link.post_description %>
       </figcaption>
     </figure>

--- a/public/base.css
+++ b/public/base.css
@@ -113,6 +113,26 @@ body > header {
     opacity: 1;
 }
 
+html:not(.currently-perverted) .show-for-perverts {
+    display: none;
+}
+
+html.currently-perverted .show-for-nonperverts {
+    display: none;
+}
+
+html:not(.current-mascot-ki) .show-for-ki {
+    display: none;
+}
+
+html:not(.current-mascot-warren) .show-for-warren {
+    display: none;
+}
+
+html:not(.current-mascot-taylor) .show-for-taylor {
+    display: none;
+}
+
 body > header h1 span {
     position: relative;
 

--- a/public/link.css
+++ b/public/link.css
@@ -830,7 +830,7 @@ figure > a.background-sample {
     display: block;
 }
 
-figure > a.background-sample img {
+figure:not(.embiggened) > a.background-sample img {
     position: absolute;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -839,17 +839,54 @@ figure > a.background-sample img {
     object-fit: cover;
 }
 
-figure > a.background-sample img.background-sample__image--desktop {
+figure:not(.embiggened) > a.background-sample img.background-sample__image--desktop {
     top: calc(50% + 6px);
     height: 96px;
     width: 136px;
 }
 
-figure > a.background-sample img.background-sample__image--mobile {
+figure:not(.embiggened) > a.background-sample img.background-sample__image--mobile {
     top: calc(50% + 8px);
     height: 160px;
     width: 81px;
 }
+
+.embiggened img.embiggen-me-daddy {
+    width:100%;
+    max-height:80vh;
+    object-fit: contain;
+}
+
+.embiggened .hide-when-embiggened {
+    display: none;
+}
+.embiggen-button-container {
+    display: flex;
+    margin: auto;
+    padding: 0;
+    max-width: 25em;
+}
+
+.embiggen-button-container button {
+    font-family: var(--sans-font);
+}
+
+.embiggen-button-container a {
+    margin: 8px 0;
+    padding: .7em .9em;
+    flex-grow: 1;
+    text-align: right;
+}
+
+
+.embiggened .embiggen-button-container button .text-embiggen {
+    display: none;
+}
+
+figure:not(.embiggened) .embiggen-button-container button .text-ensmallen {
+    display: none;
+}
+
 
 figure > a.background-sample > ion-icon {
     font-size: 180px;


### PR DESCRIPTION
sometimes, especially on mobile, it'd be easier and more convenient to kick back and sit on the web as people spam you.

i've seen people accomplish this with custom CSS on their own profiles, so I assume there's enough demand to add an actual button to do this.

- Uses SessionStorage to store the expanded/contracted state. Local on a per-tab basis; I went with SessionStorage as I wanted the expand/contract state to persist across page loads and wallpaper changes. 
- Unique expand/contract text for each lizard/perv combination. Mostly for the sake of Warren.