### PR TITLE
Direct to md5 post

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -11,7 +11,7 @@
   <p>
     <%= filtered_content %>
     <% images.each do |image| %>
-      <a target="_blank" href="https://e621.net/posts?tags=md5%3A<%= CGI.escape image[1] %>">
+      <a target="_blank" href="https://e621.net/posts?md5=<%= CGI.escape image[1] %>">
         <img src="<%= image[0] + (CGI.escape image[1]) + '.' + image[2] %>"/>
       </a>
     <% end %>

--- a/app/views/message_thread/_single_message.html.erb
+++ b/app/views/message_thread/_single_message.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <% images_source.each do |image| %>
-      <a target="_blank" href="https://e621.net/posts?tags=md5%3A<%= CGI.escape image[1] %>">
+      <a target="_blank" href="https://e621.net/posts?md5=<%= CGI.escape image[1] %>">
         <img src="<%= image[0] + (CGI.escape image[1]) + '.' + image[2] %>"/>
       </a>
     <% end %>


### PR DESCRIPTION
Rather than going to a post tag search, just go directly to the post in comments and messages.