### PR TITLE
Improve reply text display

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,7 +89,7 @@ class ApplicationController < ActionController::Base
     notification_text = "#{link.user.username} did not like your post." if link.response_type == 'disgust'
     notification_text = "#{link.user.username} came to your post!" if link.response_type == 'came'
     notification_text = "#{link.user.username} says thanks" if link.response_type == 'ok'
-    notification_text = "#{notification_text} \"#{link.response_text}\"" unless link.response_type.nil?
+    notification_text = "#{notification_text} \"#{link.response_text}\"" unless link.response_type.nil? || link.response_text.empty?
     Notification.create user_id: link.set_by_id, notification_type: :post_response, text: notification_text, link: "/links/#{link.id}"
 
     # Log reaction in chat sidebar

--- a/app/views/links/_link.html.erb
+++ b/app/views/links/_link.html.erb
@@ -205,11 +205,14 @@
       <strong>
         <%= link.user.username %>
         <% if link.horny? %>
-          😍:
+          😍
+        <% elsif link.came? %>
+          💦 came
         <% elsif link.ok? && link.response_text == '' %>
           says thanks
-        <% elsif link.came? %>
-          💦 said while cumming:
+        <% end %>
+        <% if link.response_text != '' %>
+          :
         <% end %>
       </strong>
       <%= link.response_text %>


### PR DESCRIPTION
- Removes the `:` when no response text is given.
- Slightly modifys the "came" text to fit this new schema.
- Removes the "" when response text is empty in notifications.