### PR TITLE
Add easy development setup

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,5 @@
+RAILS_ENV=development
+POSTGRES_USER=postgres
+POSTGRES_HOST_AUTH_METHOD=trust
+POSTGRES_HOST=database
+POSTGRES_DB=walltaker

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 /config/master.key
 /.idea/railways.cache
 /.idea
+
+# Environment variables
+/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ruby:3.3.4
 # Prepare working directory.
 WORKDIR /ror
 COPY ./ /ror
+
 RUN gem install bundler
 RUN bundle install
 
 # Start app server.
-CMD ["bundle", "exec", "rails", "server", "-e", "production", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "rails", "server", "-e", "${RAILS_ENV:-production}", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -126,3 +126,26 @@ Get details about this user's status such as if they're online, a friend, or the
   "self": false // 🔐 If they are logged in as this api_key's user, requires api_key param.
 }
 ```
+
+## Setup
+
+For a quick development setup, use the provided Docker Compose file.
+
+First, copy `.env.dev`:
+
+```bash
+cp .env.dev .env
+```
+
+Then, run the setup:
+
+```bash
+docker compose run --rm web /ror/bin/setup
+```
+
+Finally, start the server:
+```
+docker compose up -d
+```
+
+The server will be available at `http://localhost:3000`.

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,33 +1,26 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
-development: &development
-  <<: *default
   adapter: postgresql
   encoding: unicode
-  database: walltaker
-  username: postgres
-  password:
-  host: localhost
-  port: 5432
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+  username: <%= ENV["POSTGRES_USER"] || "postgres" %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  host: <%= ENV["POSTGRES_HOST"] %>
+  port: <%= ENV["POSTGRES_PORT"] || 5432 %>
+  database: <%= ENV["POSTGRES_DB"] %>
+
+development:
+  <<: *default
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *development
+  <<: *default
   database: walltaker_test
 
 production:
   adapter: postgresql
   encoding: unicode
   timeout: 5000
-  url: <%= ENV['DATABASE_URL'] %>
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,16 @@ services:
       - "5432:5432"
     volumes:
       - ./.docker/volumes/walltaker_database2:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_USER=postgres
+    env_file:
+      - .env
 
   web:
     build: .
     volumes:
       - ./:/ror
     ports:
-      - "3100:3000"
+      - "3000:3000"
     depends_on:
       - database
-    environment:
-      - POSTGRES_USER=postgres
-
+    env_file:
+      - .env


### PR DESCRIPTION
This PR simplifies the development setup by making it configurable via environment variables.

**Changes:**  
- Added `.env.dev` with default development environment variables.  
- Updated `Dockerfile` to support configurable environments.  
- Updated `docker-compose.yml` to use `.env` for configuration.  
- Changed web port back to 3000 (standard).
- Added setup instructions to the README.  

With these changes, setting up a development environment is as simple as:  
```bash
cp .env.dev .env
docker compose run --rm web /ror/bin/setup
docker compose up -d
```

The setup for production should remain unchanged and is the default environment for building.