### PR TITLE
Generic client agent

### DIFF
--- a/app/views/links/_link.html.erb
+++ b/app/views/links/_link.html.erb
@@ -193,7 +193,21 @@
           <span>WT Popout</span>
           <iconify-icon icon="token:rfox"></iconify-icon>
         <% when :unknown %>
-          <ion-icon role="presentation" name="help-circle-outline"></ion-icon>
+          <% if !link.last_ping_user_agent.nil? %>
+            <%
+              split = link.last_ping_user_agent.reverse.split("/", 2)
+              icon = split.length() == 2 ? split[0].reverse : nil
+              name = split.length() == 2 ? split[1].reverse : split[0].reverse
+            %>
+            <span><%= name %></span>
+            <% if icon.nil? || icon.empty? %>
+              <ion-icon role="presentation" name="help-circle-outline"></ion-icon>
+            <% else %>
+            <ion-icon name="<%= icon %>"></ion-icon>
+            <% end%>
+          <% else %>
+            <ion-icon role="presentation" name="help-circle-outline"></ion-icon>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/links/_link.html.erb
+++ b/app/views/links/_link.html.erb
@@ -203,7 +203,7 @@
             <% if icon.nil? || icon.empty? %>
               <ion-icon role="presentation" name="help-circle-outline"></ion-icon>
             <% else %>
-            <ion-icon name="<%= icon %>"></ion-icon>
+            <ion-icon name="<%= icon %>-outline"></ion-icon>
             <% end%>
           <% else %>
             <ion-icon role="presentation" name="help-circle-outline"></ion-icon>


### PR DESCRIPTION
Allows for any client to announce themselves, and give it one of the [ionicons](https://ionic.io/ionicons). It only requires the base icon name, as to stay with the rest of the style of the site.

This has worked well over websocket clients. However, with the way the API clients work, I'm not entirely sure how well it'll work if the user is running multiple clients on the same link, but those should all override any generic client.

Anything before the last `/` is part of the client name, after will be the icon name.

Example agents: 
`TestClient/laptop` will show:
![4lqmo_22951 1](https://github.com/user-attachments/assets/0f447cf8-01fc-4d99-b349-eea2cd942848)
`TestClient/1.0.0/phone-portrait` will show:
![uw3mlw_22952 1](https://github.com/user-attachments/assets/b62fb824-4a45-43b6-a896-806011732dc5)

And so on. If a client wishes to have a slash in their client name to show, for example, versioning, but not define an icon, it can do so by leaving a trailing slash: `TestClient/1.0.0/`

