### PR TITLE
Add User-Agents for iPhones and iPads

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -36,6 +36,8 @@ module LinksHelper
     return :pawslut if link_agent.include? 'PawSlut'
     return :collin if link_agent.include? 'umbrella Collin\'s Walltaker Setter Thing'
     return :pawbies if link_agent.include? 'WTPopOutViewer'
+    return :ios_iphone if link_agent.include? 'WalltakeriOS-iPhone-Shortcut (mikapika.)'
+    return :ios_ipad if link_agent.include? 'WalltakeriOS-iPad-Shortcut (mikapika.)'
     :unknown
   end
 

--- a/app/views/links/_details.html.erb
+++ b/app/views/links/_details.html.erb
@@ -20,6 +20,8 @@
   pawslut: :desktop,
   collin: :desktop,
   pawbies: :desktop,
+  ios_ipad: :desktop,
+  ios_iphone: :mobile,
   unknown: :desktop
 } %>
 <% device = devices[client] %>

--- a/public/base.css
+++ b/public/base.css
@@ -475,8 +475,10 @@ h3 span.beta-tag {
 
 h2 > .online {
     font-size: 1rem;
-    transform: translateY(-0.9rem);
+    vertical-align: middle;
+    transform: none;
     display: inline-block;
+    padding-bottom: 0;
 }
 
 h2 ion-icon {

--- a/public/link.css
+++ b/public/link.css
@@ -284,11 +284,12 @@ strong.online ion-icon {
 strong.online::after {
     content: '';
     display: inline-block;
-    width: 1ch;
-    height: 1ch;
+    width: 10px;
+    height: 10px;
     background: currentColor;
     border-radius: 100%;
     margin-left: 0.25rem;
+    vertical-align: 3px;    
 }
 
 strong.offline {


### PR DESCRIPTION
I have created a way to use the Walltaker API on an iOS device with the Shortcuts app. The shortcut pings Walltaker with the User-Agent headers listed in `links_helper.rb` and the devices in `_details.html.erb` correspond the iPhone and iPad to `mobile` and `desktop` respectively.