### PR TITLE
Fix exception on webp images.

### DIFF
--- a/app/views/links/_details.html.erb
+++ b/app/views/links/_details.html.erb
@@ -1,5 +1,5 @@
 <% target = "link_details_#{link.id}" %>
-<% e621_url = "https://e621.net/posts?md5=#{ CGI.escape(link.post_url[/\w*(?=\.(png|jpg|bmp|webm|mp4|gif)$)/]) }" if link.post_url %>
+<% e621_url = "https://e621.net/posts?md5=#{ CGI.escape(link.post_url[/\w*(?=\.(png|jpg|bmp|webm|mp4|gif|webp)$)/]) }" if link.post_url %>
 <% client = link_agent_to_icon link.last_ping_user_agent %>
 <% devices = {
   desktop: :desktop,


### PR DESCRIPTION
This prevents the increasingly common error that occurs when a link is set to a webp image. Should allow for viewing and setting posts on a link when it is assigned a webp e6 post.